### PR TITLE
Update README to remove demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 A lightweight Saleor app template leveraging Hono's ultrafast routing capabilities (under 14kB) and Cloudflare Pages for deployment.
 
-## Demo
-
-Experience the live demo at: https://saleor-app-hono-pages-template.pages.dev/
-
 ## Overview
 
 This template provides a foundation for building Saleor apps using the Hono framework, featuring:


### PR DESCRIPTION
Removed demo section from README - deployment was made on my private account and I decided to remove it for security reasons and lack of time to maintain this ;)